### PR TITLE
Improve error types implementation.

### DIFF
--- a/changes/55.change.md
+++ b/changes/55.change.md
@@ -1,0 +1,1 @@
+Error types are now truly forced to be non-empty.

--- a/wraps/wraps/error_types.py
+++ b/wraps/wraps/error_types.py
@@ -1,69 +1,48 @@
-from typing import Type, TypeVar
+from __future__ import annotations
 
-from annotated_types import MinLen
-from typing_aliases import AnyError, DynamicTuple
-from typing_extensions import Annotated, TypeIs
+from typing import Generic, Type, TypeVar
+
+from attrs import Attribute, field, frozen
+from typing_aliases import AnyError, DynamicTuple, EmptyTuple
+from typing_extensions import Self, TypeIs
 
 from wraps.panics import panic
 
-__all__ = (
-    "ErrorTypesMaybeEmpty",
-    "ErrorTypes",
-    "is_error_types",
-    "expect_error_types",
-    "expect_error_types_runtime",
-)
+__all__ = ("RawErrorTypes", "ErrorTypes")
+
+T = TypeVar("T")
+
+
+def is_empty_tuple(dynamic_tuple: DynamicTuple[T]) -> TypeIs[EmptyTuple]:
+    return not dynamic_tuple
+
 
 E = TypeVar("E", bound=AnyError)
 
-ErrorTypesMaybeEmpty = DynamicTuple[Type[E]]
-"""Represents error types that may be empty.
-`E` is bound to [`AnyError`][typing_aliases.AnyError].
-"""
+RawErrorTypes = DynamicTuple[Type[E]]
+"""Represents error types. `E` is bound to [`AnyError`][typing_aliases.AnyError]."""
 
-ErrorTypes = Annotated[ErrorTypesMaybeEmpty[E], MinLen(1)]
-"""Represents non-empty error types. `E` is bound to [`AnyError`][typing_aliases.AnyError]."""
-
-
-EXPECTED_ERROR_TYPES = "expected `ErrorTypes[E]` (non-empty `DynamicTuple[Type[E]]`), got {}"
+EXPECTED_ERROR_TYPES = "`ErrorTypes[E]` expected non-empty `RawErrorTypes[E]`, got `{}`"
 expected_error_types = EXPECTED_ERROR_TYPES.format
 
 
-def is_error_types(error_types: ErrorTypesMaybeEmpty[E]) -> TypeIs[ErrorTypes[E]]:
-    """Checks if the `error_types` tuple provided is non-empty.
+@frozen()
+class ErrorTypes(Generic[E]):
+    """Represents non-empty error types. `E` is bound to [`AnyError`][typing_aliases.AnyError]."""
 
-    Arguments:
-        error_types: The tuple of error types to check.
+    raw: RawErrorTypes[E] = field()
+    """Raw error types."""
 
-    Returns:
-        Whether the provided tuple is non-empty.
-    """
-    return len(error_types) >= 1
+    @raw.validator
+    def check_raw(self, attribute: Attribute[RawErrorTypes[E]], value: RawErrorTypes[E]) -> None:
+        if is_empty_tuple(value):
+            panic(expected_error_types(value))
 
+    @classmethod
+    def from_head_and_tail(cls, head: Type[E], *tail: Type[E]) -> Self:
+        raw = (head, *tail)
 
-def expect_error_types(error_types_maybe_empty: ErrorTypesMaybeEmpty[E]) -> ErrorTypes[E]:
-    """Expects error types provided to be non-empty.
+        return cls(raw)
 
-    Warning:
-        This function panics if the error types are empty.
-
-    Arguments:
-        error_types_maybe_empty: The error types to check.
-
-    Raises:
-        Panic: If the error types are empty.
-
-    Returns:
-        The error types if they are non-empty.
-    """
-    if is_error_types(error_types_maybe_empty):
-        return error_types_maybe_empty
-
-    panic(expected_error_types(error_types_maybe_empty))
-
-
-def expect_error_types_runtime(error_types: ErrorTypes[E]) -> ErrorTypes[E]:
-    """Same as [`expect_error_types`][wraps.wraps.error_types.expect_error_types],
-    but for runtime checks only.
-    """
-    return expect_error_types(error_types)
+    def extract(self) -> RawErrorTypes[E]:
+        return self.raw


### PR DESCRIPTION
Error types are truly forced to be non-empty.